### PR TITLE
Embed fixes: Size, wrapping, start/end embeds

### DIFF
--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -109,19 +109,18 @@ module Squib
         rule          = embed.rules[key]
         spacing       = rule[:width] * Pango::SCALE
         index         = clean_str.index(key)
-        str.sub!(key, "<span letter_spacing=\"#{spacing.to_i}\"> </span>")
+        str.sub!(key, "<span size=\"0\">a<span letter_spacing=\"#{spacing.to_i}\">a</span></span>")
         layout.markup = str
         clean_str     = layout.text
         rect          = layout.index_to_pos(index)
         iter          = layout.iter
         while iter.next_char! && iter.index < index; end
-        letter_width  = iter.char_extents.width - spacing # the width of our inserted space char
         case layout.alignment
           when Pango::Layout::Alignment::CENTER,
                Pango::Layout::Alignment::RIGHT
             Squib.logger.warn "Center- or right-aligned text do not always embed properly. This is a known issue with a workaround. See https://github.com/andymeneely/squib/issues/46"
         end
-        x             = Pango.pixels(rect.x + (letter_width / 2)) + rule[:dx]
+        x             = Pango.pixels(rect.x) + rule[:dx]
         y             = Pango.pixels(rect.y) + rule[:dy]
         draw_calls << {x: x, y: y, draw: rule[:draw]} # defer drawing until we've valigned
       end

--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -109,7 +109,7 @@ module Squib
         rule          = embed.rules[key]
         spacing       = rule[:width] * Pango::SCALE
         index         = clean_str.index(key)
-        str.sub!(key, "<span size=\"0\">a<span letter_spacing=\"#{spacing.to_i}\">a</span></span>")
+        str.sub!(key, "<span size=\"0\">a<span letter_spacing=\"#{spacing.to_i}\">a</span>a</span>")
         layout.markup = str
         clean_str     = layout.text
         rect          = layout.index_to_pos(index)

--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -117,8 +117,6 @@ module Squib
       end
       searches.each do |search|
         rect          = layout.index_to_pos(search[:index])
-        iter          = layout.iter
-        while iter.next_char! && iter.index < search[:index]; end
         case layout.alignment
           when Pango::Layout::Alignment::CENTER,
                Pango::Layout::Alignment::RIGHT


### PR DESCRIPTION
Setting the size to zero both eliminates the extra space padding the icons without any calcuations, and hides the characters we are putting in to fix the other issues. Setting the replacement character to a word character instead of a space fixes the space shrinking, disappearing, or wrapping incorrectly. Adding additional word characters on either side prevents size issues when the replacement character itself becomes the first or last item in the string. 

Each draw call's location is only calculated after all string replacements have been completed. If this was not done, wrapping for each image would take into account the size of the text being replaced, not the image replacing it, for each item that has not yet been processed.

This may remedy the center and right aligned embed issue as well; I did not see any incorrectly-located embeds in limited testing. If you have the cases that were causing problems previously, please test them now and see if they still are.