### PR TITLE
fixes #56 by accounting for case that would produce zero rows

### DIFF
--- a/lib/squib/input_helpers.rb
+++ b/lib/squib/input_helpers.rb
@@ -221,7 +221,11 @@ module Squib
     def rowify(opts)
       unless opts[:rows].respond_to? :to_i
         raise "Columns must be an integer" unless opts[:columns].respond_to? :to_i
-        opts[:rows] = (@cards.size / opts[:columns].to_i).ceil
+        if @cards.size < opts[:columns].to_i
+          opts[:rows] = 1
+        else
+          opts[:rows] = (@cards.size / opts[:columns].to_i).ceil
+        end
       end
       opts
     end

--- a/spec/input_helpers_spec.rb
+++ b/spec/input_helpers_spec.rb
@@ -182,17 +182,28 @@ describe Squib::InputHelpers do
   end
 
   context '#rowify' do
+    before(:each) do
+      @default_opts = { rows: :infinite, columns: 5 }
+    end
+    
     it 'does nothing on an integer' do
-      opts = @deck.send(:rowify, {columns: 2, rows: 2})
+      opts = @deck.send(:rowify, @default_opts.merge({columns: 2, rows: 2}))
       expect(opts).to eq({ columns: 2,
                            rows: 2
                         })
     end
 
     it 'computes properly on non-integer' do
-      opts = @deck.send(:rowify, {columns: 1, rows: :infinite})
+      opts = @deck.send(:rowify, @default_opts.merge({columns: 1, rows: :infinite}))
       expect(opts).to eq({ columns: 1,
                            rows: 2
+                        })
+    end
+    
+    it 'computes properly on unspecified rows' do
+      opts = @deck.send(:rowify, @default_opts.merge({columns: 3}))
+      expect(opts).to eq({ columns: 3,
+                           rows: 1
                         })
     end
   end


### PR DESCRIPTION
I dunno if I was creating a PR to the wrong branch last i tried this, but this one should pass the build. The example case in #56 was causing `opts[:rows]` to be set to `0` in `rowify`.