### PR TITLE
Preset card size methods and groundwork for better n-up support

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,15 @@
 c
+n
+vendor_opts['items'].include? card
+vendor_opts
+n
+c
+s
+c
+s
+c
+n
+c
 args
 c
 args.first

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,7 @@
+c
+args
+c
+args.first
+args
+c
+args

--- a/lib/squib.rb
+++ b/lib/squib.rb
@@ -2,10 +2,10 @@ require 'logger'
 require 'cairo'
 require 'pango'
 require 'rsvg2'
-require 'squib/version'
-require 'squib/commands/new'
-require 'squib/deck'
-require 'squib/card'
+require_relative 'squib/version'
+require_relative 'squib/commands/new'
+require_relative 'squib/deck'
+require_relative 'squib/card'
 
 module Squib
 

--- a/lib/squib/api/data.rb
+++ b/lib/squib/api/data.rb
@@ -1,7 +1,7 @@
 require 'roo'
 require 'csv'
-require 'squib/args/input_file'
-require 'squib/args/import'
+require_relative '../args/input_file'
+require_relative '../args/import'
 
 module Squib
 

--- a/lib/squib/api/image.rb
+++ b/lib/squib/api/image.rb
@@ -1,9 +1,9 @@
-require 'squib/args/card_range'
-require 'squib/args/paint'
-require 'squib/args/scale_box'
-require 'squib/args/transform'
-require 'squib/args/input_file'
-require 'squib/args/svg_special'
+require_relative '../args/card_range'
+require_relative '../args/paint'
+require_relative '../args/scale_box'
+require_relative '../args/transform'
+require_relative '../args/input_file'
+require_relative '../args/svg_special'
 
 module Squib
   class Deck

--- a/lib/squib/api/save.rb
+++ b/lib/squib/api/save.rb
@@ -51,7 +51,7 @@ module Squib
     #
     # Options support Arrays, see {file:README.md#Arrays_and_Singleton_Expansion Arrays and Singleon Expansion}
     #
-    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}. add -A
+    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
     # @option opts [String] dir (_output) the directory for the output to be sent to. Will be created if it doesn't exist.
     # @option opts [String] prefix (card_) the prefix of the file name to be printed.
     # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics).

--- a/lib/squib/api/save.rb
+++ b/lib/squib/api/save.rb
@@ -89,9 +89,6 @@ module Squib
     # @return [nil]
     # @api public
     def save_sheet(opts = {})
-
-
-    # def save_parsed_sheet(opts = {})
       opts[:trim] ||= @bleed || 0 #sets trim to arg if given, else bleed attribute of deck if present, else 0
       range = Args::CardRange.new(opts[:range], deck_size: size)
       batch = Args::SaveBatch.new.load!(opts, expand_by: size, layout: layout, dpi: dpi)

--- a/lib/squib/api/save.rb
+++ b/lib/squib/api/save.rb
@@ -7,7 +7,7 @@ require 'squib/args/showcase_special'
 module Squib
   class Deck
 
-    # Saves the given range of cards to either PNG or PDF
+    # Saves the given range of cards to either PNG or PDF or both
     #
     #
     # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}
@@ -33,11 +33,12 @@ module Squib
     # @option opts width [Integer] (3300) the height of the page in pixels. Default is 11in * 300dpi. Supports unit conversion.
     # @option opts height [Integer] (2550) the height of the page in pixels. Default is 8.5in * 300dpi. Supports unit conversion.
     # @option opts margin [Integer] (75) the margin around the outside of the page. Supports unit conversion.
-    # @option opts gap [Integer] (0) the space in pixels between the cards. Supports unit conversion.
+    # @option opts gap [Integer] (0) the space in pixels between the cards. Supports unit conversion.  Defautls to bleed attribute of deck if specified.
     # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play). Supports unit conversion.
     # @return [nil]
     # @api public
     def save_pdf(opts = {})
+      opts[:trim] ||= @bleed || 0 #sets trim to arg if given, else bleed attribute of deck if present, else 0.
       range = Args::CardRange.new(opts[:range], deck_size: size)
       sheet = Args::Sheet.new(custom_colors, {file: 'output.pdf'}).load!(opts, expand_by: size, layout: layout, dpi: dpi)
       render_pdf(range, sheet)
@@ -50,16 +51,17 @@ module Squib
     #
     # Options support Arrays, see {file:README.md#Arrays_and_Singleton_Expansion Arrays and Singleon Expansion}
     #
-    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}
+    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
     # @option opts [String] dir (_output) the directory for the output to be sent to. Will be created if it doesn't exist.
     # @option opts [String] prefix (card_) the prefix of the file name to be printed.
-    # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics)
+    # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics).
     # @option opts [Boolean, :clockwise, :counterclockwise] rotate (false) if true, the saved cards will be rotated 90 degrees clockwise. Or, rotate by the number of radians. Intended to rendering landscape instead of portrait.
-    # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play). Supports unit conversion.
-    # @option opts trim_radius [Integer] (38) the rounded rectangle radius around the card to trim before putting into the showcase
-    # @return [nil] Returns nothing
+    # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play). Supports unit conversion. Defautls to bleed attribute of deck if specified.
+    # @option opts trim_radius [Integer] (38) the rounded rectangle radius around the card to trim before putting into the showcase.
+    # @return [nil] Returns nothing.
     # @api public
     def save_png(opts = {})
+      opts[:trim] ||= @bleed || 0 #sets trim to arg if given, else bleed attribute of deck if present, else 0.
       range = Args::CardRange.new(opts[:range], deck_size: size)
       batch = Args::SaveBatch.new.load!(opts, expand_by: size, layout: layout, dpi: dpi)
       @progress_bar.start("Saving PNGs to #{batch.summary}", size) do |bar|
@@ -75,18 +77,19 @@ module Squib
     # @example
     #   save_sheet prefix: 'sheet_', margin: 75, gap: 5, trim: 37
     #
-    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}
-    # @option opts columns [Integer] (5) the number of columns in the grid. Must be an integer
+    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
+    # @option opts columns [Integer] (5) the number of columns in the grid. Must be an integer.
     # @option opts rows [Integer] (:infinite) the number of rows in the grid. When set to :infinite, the sheet scales to the rows needed. If there are more cards than rows*columns, new sheets are started.
-    # @option opts [String] prefix (card_) the prefix of the file name(s)
+    # @option opts [String] prefix (card_) the prefix of the file name(s).
     # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics)
     # @option opts dir [String] (_output) the directory to save to. Created if it doesn't exist.
     # @option opts margin [Integer] (0) the margin around the outside of the sheet.
-    # @option opts gap [Integer] (0) the space in pixels between the cards
-    # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play)
+    # @option opts gap [Integer] (0) the space in pixels between the cards.
+    # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play). Defautls to bleed attribute of deck if specified.
     # @return [nil]
     # @api public
     def save_sheet(opts = {})
+      opts[:trim] ||= @bleed || 0 #sets trim to arg if given, else bleed attribute of deck if present, else 0
       range = Args::CardRange.new(opts[:range], deck_size: size)
       batch = Args::SaveBatch.new.load!(opts, expand_by: size, layout: layout, dpi: dpi)
       sheet = Args::Sheet.new(custom_colors, {margin: 0}, size).load!(opts, expand_by: size, layout: layout, dpi: dpi)

--- a/lib/squib/api/save.rb
+++ b/lib/squib/api/save.rb
@@ -76,14 +76,15 @@ module Squib
     #
     # @example
     #   save_sheet prefix: 'sheet_', margin: 75, gap: 5, trim: 37
-    # @option opts [:none, :9up :8up, :game_crafter, :pnp_prod, :drive_thru_cards]
     # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
     # @option opts columns [Integer] (5) the number of columns in the grid. Must be an integer.
     # @option opts rows [Integer] (:infinite) the number of rows in the grid. When set to :infinite, the sheet scales to the rows needed. If there are more cards than rows*columns, new sheets are started.
     # @option opts [String] prefix (card_) the prefix of the file name(s).
     # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics)
     # @option opts dir [String] (_output) the directory to save to. Created if it doesn't exist.
-    # @option opts margin [Integer] (0) the margin around the outside of the sheet.
+    ##Need to modify code to accept different x and y margins
+    # @option opts margin-x [Integer] (0) the margin around the outside of the sheet.
+    # @option opts margin-x [Integer] (0) the margin around the outside of the sheet.
     # @option opts gap [Integer] (0) the space in pixels between the cards.
     # @option opts trim [Integer] (0) the space around the edge of each card to trim (e.g. to cut off the bleed margin for print-and-play). Defautls to bleed attribute of deck if specified.
     # @return [nil]
@@ -95,6 +96,17 @@ module Squib
       sheet = Args::Sheet.new(custom_colors, {margin: 0}, size).load!(opts, expand_by: size, layout: layout, dpi: dpi)
       render_sheet(range, batch, sheet)
     end
+
+    # Additional Option: page_size [:letter, :a4] default: :letter
+    def save_9up opts = {}
+      opts[:page_size] ||= :letter
+      opts[:trim] ||= @bleed || 0
+      opts[:gap] = 2
+      opts[:columns] = 3
+      opts[:rows] = 3
+      opts[:margin] = calculate_margin(opts[:page_size], rows: 3, columns: 3, gap: 2)
+    end
+
 
     
 

--- a/lib/squib/api/save.rb
+++ b/lib/squib/api/save.rb
@@ -1,8 +1,8 @@
-require 'squib/args/card_range'
-require 'squib/args/hand_special'
-require 'squib/args/save_batch'
-require 'squib/args/sheet'
-require 'squib/args/showcase_special'
+require_relative '../args/card_range'
+require_relative '../args/hand_special'
+require_relative '../args/save_batch'
+require_relative '../args/sheet'
+require_relative '../args/showcase_special'
 
 module Squib
   class Deck
@@ -51,7 +51,7 @@ module Squib
     #
     # Options support Arrays, see {file:README.md#Arrays_and_Singleton_Expansion Arrays and Singleon Expansion}
     #
-    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
+    # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}. add -A
     # @option opts [String] dir (_output) the directory for the output to be sent to. Will be created if it doesn't exist.
     # @option opts [String] prefix (card_) the prefix of the file name to be printed.
     # @option opts [String] count_format (%02d) the format string used for formatting the card count (e.g. padding zeros). Uses a Ruby format string (see the Ruby doc for Kernel::sprintf for specifics).
@@ -76,7 +76,7 @@ module Squib
     #
     # @example
     #   save_sheet prefix: 'sheet_', margin: 75, gap: 5, trim: 37
-    #
+    # @option opts [:none, :9up :8up, :game_crafter, :pnp_prod, :drive_thru_cards]
     # @option opts [Enumerable] range (:all) the range of cards over which this will be rendered. See {file:README.md#Specifying_Ranges Specifying Ranges}.
     # @option opts columns [Integer] (5) the number of columns in the grid. Must be an integer.
     # @option opts rows [Integer] (:infinite) the number of rows in the grid. When set to :infinite, the sheet scales to the rows needed. If there are more cards than rows*columns, new sheets are started.
@@ -89,12 +89,17 @@ module Squib
     # @return [nil]
     # @api public
     def save_sheet(opts = {})
+
+
+    # def save_parsed_sheet(opts = {})
       opts[:trim] ||= @bleed || 0 #sets trim to arg if given, else bleed attribute of deck if present, else 0
       range = Args::CardRange.new(opts[:range], deck_size: size)
       batch = Args::SaveBatch.new.load!(opts, expand_by: size, layout: layout, dpi: dpi)
       sheet = Args::Sheet.new(custom_colors, {margin: 0}, size).load!(opts, expand_by: size, layout: layout, dpi: dpi)
       render_sheet(range, batch, sheet)
     end
+
+    
 
     # Renders a range of cards in a showcase as if they are sitting in 3D on a reflective surface
     # See {file:samples/showcase.rb} for full example

--- a/lib/squib/api/shapes.rb
+++ b/lib/squib/api/shapes.rb
@@ -1,8 +1,8 @@
-require 'squib/args/box'
-require 'squib/args/draw'
-require 'squib/args/card_range'
-require 'squib/args/transform'
-require 'squib/args/coords'
+require_relative '../args/box'
+require_relative '../args/draw'
+require_relative '../args/card_range'
+require_relative '../args/transform'
+require_relative '../args/coords'
 
 module Squib
   class Deck

--- a/lib/squib/api/text.rb
+++ b/lib/squib/api/text.rb
@@ -1,8 +1,8 @@
-require 'squib/api/text_embed'
-require 'squib/args/box'
-require 'squib/args/card_range'
-require 'squib/args/draw'
-require 'squib/args/paragraph'
+require_relative '../api/text_embed'
+require_relative '../args/box'
+require_relative '../args/card_range'
+require_relative '../args/draw'
+require_relative '../args/paragraph'
 
 module Squib
   class Deck

--- a/lib/squib/api/text_embed.rb
+++ b/lib/squib/api/text_embed.rb
@@ -1,10 +1,10 @@
-require 'squib/args/box'
-require 'squib/args/card_range'
-require 'squib/args/embed_adjust'
-require 'squib/args/embed_key'
-require 'squib/args/input_file'
-require 'squib/args/paint'
-require 'squib/args/transform'
+require_relative '../args/box'
+require_relative '../args/card_range'
+require_relative '../args/embed_adjust'
+require_relative '../args/embed_key'
+require_relative '../args/input_file'
+require_relative '../args/paint'
+require_relative '../args/transform'
 
 module Squib
   class TextEmbed

--- a/lib/squib/api/units.rb
+++ b/lib/squib/api/units.rb
@@ -1,4 +1,4 @@
-require 'squib/constants'
+require_relative '../constants'
 
 module Squib
   class Deck

--- a/lib/squib/args/arg_loader.rb
+++ b/lib/squib/args/arg_loader.rb
@@ -1,5 +1,5 @@
-require 'squib/constants'
-require 'squib/conf'
+require_relative '../constants'
+require_relative '../conf'
 require 'ostruct'
 
 module Squib

--- a/lib/squib/args/box.rb
+++ b/lib/squib/args/box.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/box.rb
+++ b/lib/squib/args/box.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/coords.rb
+++ b/lib/squib/args/coords.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/coords.rb
+++ b/lib/squib/args/coords.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/draw.rb
+++ b/lib/squib/args/draw.rb
@@ -1,6 +1,6 @@
 require 'cairo'
-require 'squib/args/arg_loader'
-require 'squib/args/color_validator'
+require_relative '../args/arg_loader'
+require_relative '../args/color_validator'
 
 module Squib
   # @api private

--- a/lib/squib/args/draw.rb
+++ b/lib/squib/args/draw.rb
@@ -1,5 +1,5 @@
 require 'cairo'
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../args/color_validator'
 
 module Squib

--- a/lib/squib/args/embed_adjust.rb
+++ b/lib/squib/args/embed_adjust.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/embed_adjust.rb
+++ b/lib/squib/args/embed_adjust.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/embed_key.rb
+++ b/lib/squib/args/embed_key.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/embed_key.rb
+++ b/lib/squib/args/embed_key.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/import.rb
+++ b/lib/squib/args/import.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/import.rb
+++ b/lib/squib/args/import.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/input_file.rb
+++ b/lib/squib/args/input_file.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/input_file.rb
+++ b/lib/squib/args/input_file.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/paint.rb
+++ b/lib/squib/args/paint.rb
@@ -1,6 +1,6 @@
 require 'cairo'
-require 'squib/args/arg_loader'
-require 'squib/args/color_validator'
+require_relative '../args/arg_loader'
+require_relative '../args/color_validator'
 
 module Squib
   # @api private

--- a/lib/squib/args/paint.rb
+++ b/lib/squib/args/paint.rb
@@ -1,5 +1,5 @@
 require 'cairo'
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../args/color_validator'
 
 module Squib

--- a/lib/squib/args/paragraph.rb
+++ b/lib/squib/args/paragraph.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../constants'
 
 module Squib

--- a/lib/squib/args/paragraph.rb
+++ b/lib/squib/args/paragraph.rb
@@ -1,5 +1,5 @@
-require 'squib/args/arg_loader'
-require 'squib/constants'
+require_relative '../args/arg_loader'
+require_relative '../constants'
 
 module Squib
   # @api private

--- a/lib/squib/args/save_batch.rb
+++ b/lib/squib/args/save_batch.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../args/dir_validator'
 
 module Squib

--- a/lib/squib/args/save_batch.rb
+++ b/lib/squib/args/save_batch.rb
@@ -1,5 +1,5 @@
-require 'squib/args/arg_loader'
-require 'squib/args/dir_validator'
+require_relative '../args/arg_loader'
+require_relative '../args/dir_validator'
 
 module Squib
   # @api private

--- a/lib/squib/args/scale_box.rb
+++ b/lib/squib/args/scale_box.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/scale_box.rb
+++ b/lib/squib/args/scale_box.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/sheet.rb
+++ b/lib/squib/args/sheet.rb
@@ -1,7 +1,7 @@
 require 'cairo'
-require 'squib/args/arg_loader'
-require 'squib/args/color_validator'
-require 'squib/args/dir_validator'
+require_relative '../args/arg_loader'
+require_relative '../args/color_validator'
+require_relative '../args/dir_validator'
 
 module Squib
   # @api private

--- a/lib/squib/args/sheet.rb
+++ b/lib/squib/args/sheet.rb
@@ -1,5 +1,5 @@
 require 'cairo'
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../args/color_validator'
 require_relative '../args/dir_validator'
 

--- a/lib/squib/args/showcase_special.rb
+++ b/lib/squib/args/showcase_special.rb
@@ -1,5 +1,5 @@
 require 'cairo'
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 require_relative '../args/dir_validator'
 
 module Squib

--- a/lib/squib/args/showcase_special.rb
+++ b/lib/squib/args/showcase_special.rb
@@ -1,6 +1,6 @@
 require 'cairo'
-require 'squib/args/arg_loader'
-require 'squib/args/dir_validator'
+require_relative '../args/arg_loader'
+require_relative '../args/dir_validator'
 
 module Squib
   # @api private

--- a/lib/squib/args/svg_special.rb
+++ b/lib/squib/args/svg_special.rb
@@ -1,4 +1,4 @@
-require_relative '../args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/svg_special.rb
+++ b/lib/squib/args/svg_special.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative '../args/arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/transform.rb
+++ b/lib/squib/args/transform.rb
@@ -1,4 +1,4 @@
-require 'squib/args/arg_loader'
+require_relative 'arg_loader'
 
 module Squib
   # @api private

--- a/lib/squib/args/typographer.rb
+++ b/lib/squib/args/typographer.rb
@@ -1,4 +1,4 @@
-require 'squib/constants'
+require_relative '../constants'
 module Squib
   #@api private
   module Args

--- a/lib/squib/args/unit_conversion.rb
+++ b/lib/squib/args/unit_conversion.rb
@@ -1,4 +1,4 @@
-require 'squib/constants'
+require_relative '../constants'
 
 module Squib
   module Args

--- a/lib/squib/args/vendor_args.rb
+++ b/lib/squib/args/vendor_args.rb
@@ -1,0 +1,34 @@
+module Squib
+  #@api private
+  module Args
+    # Internal class for handling arguments
+    #@api private
+    class VendorArgs
+
+      def self.base_options (card)
+      	  base_opts = YAML.load_file("#{File.dirname(__FILE__)}/../vendor/base.yml")
+        if base_opts.keys.include?(card)
+          return base_opts[card]
+        else
+          raise ArgumentError.new "Card type \"#{card.to_s}\" is not supported."
+        end
+      end
+
+      def self.vendor_options (card, vendor)
+
+          vendor_opts = YAML.load_file("#{File.dirname(__FILE__)}/../vendor/#{vendor}.yml")
+          if  vendor_opts['items'].include? card
+            return vendor_opts['specs']
+          else
+            Squib.logger.warn "Card type \"#{card.to_s}\" is not supported by vendor \"#{vendor}.\"  Using defaults."
+            return nil
+          end
+
+        rescue SystemCallError
+          Squib::logger.warn "Vendor \"#{vendor}\" not found.  Using defaults."
+          return nil
+      	end
+
+    end
+  end
+end

--- a/lib/squib/card.rb
+++ b/lib/squib/card.rb
@@ -1,5 +1,5 @@
 require 'cairo'
-require 'squib/graphics/cairo_context_wrapper'
+require_relative 'graphics/cairo_context_wrapper'
 
 module Squib
   # Back end graphics. Private.

--- a/lib/squib/card.rb
+++ b/lib/squib/card.rb
@@ -54,13 +54,13 @@ module Squib
     ########################
     ### BACKEND GRAPHICS ###
     ########################
-    require 'squib/graphics/background'
-    require 'squib/graphics/image'
-    require 'squib/graphics/save_doc'
-    require 'squib/graphics/save_images'
-    require 'squib/graphics/shapes'
-    require 'squib/graphics/showcase'
-    require 'squib/graphics/text'
+    require_relative 'graphics/background'
+    require_relative 'graphics/image'
+    require_relative 'graphics/save_doc'
+    require_relative 'graphics/save_images'
+    require_relative 'graphics/shapes'
+    require_relative 'graphics/showcase'
+    require_relative 'graphics/text'
 
   end
 end

--- a/lib/squib/conf.rb
+++ b/lib/squib/conf.rb
@@ -1,5 +1,5 @@
 require 'forwardable'
-require 'squib'
+require_relative '../squib'
 require_relative 'args/typographer'
 require 'yaml'
 

--- a/lib/squib/conf.rb
+++ b/lib/squib/conf.rb
@@ -1,6 +1,6 @@
 require 'forwardable'
 require 'squib'
-require 'squib/args/typographer'
+require_relative 'args/typographer'
 require 'yaml'
 
 module Squib

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -10,7 +10,6 @@ require_relative 'graphics/showcase'
 require_relative 'layout_parser'
 require_relative 'progress'
 
-require 'byebug'
 
 # The project module
 #
@@ -53,14 +52,14 @@ module Squib
     #
     # @param width [Integer] the width of each card in pixels. Supports unit conversion (e.g. '2.5in').
     # @param height [Integer] the height of each card in pixels. Supports unit conversion (e.g. '3.5in').
+    # @param bleed [Integer] the size of the bleed in pixels. Supports unit conversion(e.g. '0.125in').  Height and width should specify the final size of the card after trimming, the actual size of the card will be extended by the bleed on all sides.  Thus, a card specified with a width of 2.5in, a height of 3.5in, and a bleed of 0.125in will have a total size of 2.75in by 3.75in. 
     # @param cards [Integer] the number of cards in the deck.
     # @param dpi [Integer] the pixels per inch when rendering out to PDF or calculating using inches.
-    # @param bleed [Integer] the size of the bleed in pixels. Supports unit conversion(e.g. '0.125in').
     # @param config [String] the file used for global settings of this deck.
     # @param layout [String, Array] load a YML file of custom layouts. Multiple files are merged sequentially, redefining collisons. See README and sample for details.
     # @param block [Block] the main body of the script.
     # @api public
-    def initialize(width: 825, height: 1125, cards: 1, dpi: 300, bleed: 0, config: 'config.yml', layout: nil,  &block)
+    def initialize(width: 825, height: 1125, cards: 1, dpi: 300, bleed: 0, config: 'config.yml', layout: nil, **factory_args,  &block)
       @bleed       = Args::UnitConversion.parse bleed, dpi 
       @dpi           = dpi
       @font          = DEFAULT_FONT
@@ -68,38 +67,42 @@ module Squib
       @conf          = Conf.load(config)
       @progress_bar  = Progress.new(@conf.progress_bars) # FIXME this is evil. Using something different with @ and non-@
       show_info(config, layout)
-      @width         = Args::UnitConversion.parse width, dpi
-      @height        = Args::UnitConversion.parse height, dpi
+      @width         = Args::UnitConversion.parse(width, dpi) + @bleed * 2
+      @height        = Args::UnitConversion.parse(height, dpi) + @bleed * 2
       cards.times{ |i| @cards << Squib::Card.new(self, @width, @height, i) }
       @layout        = LayoutParser.load_layout(layout)
+      @card_name = factory_args[:card_name]
+      @vendor = factory_args[:vendor]
       if block_given?
         instance_eval(&block) # here we go. wheeeee!
       end
     end
 
     def self.method_missing(card, args = nil, &block)
-      if args.is_a?(Hash)
-        vendor = args.keys.include?(:vendor) ? args[:vendor] : nil
-        if vendor
-          vendor_opts = YAML.load_file("#{File.dirname(__FILE__)}/vendor/#{vendor}.yml")
-          if  vendor_opts['items'].include? card.to_s
-            vendor_args = vendor_opts['specs'][card.to_s] || vendor_opts['specs']['default']
+      if args
+        if args.is_a?(Hash) 
+          vendor = args.keys.include?(:vendor) ? args[:vendor] : nil
+          # Add error handling if invalid params.
+          if vendor
+            vendor_opts = YAML.load_file("#{File.dirname(__FILE__)}/vendor/#{vendor}.yml")
+            if  vendor_opts['items'].include? card.to_s
+              vendor_args = vendor_opts['specs'] || vendor_opts['specs']['default']
+            end
           end
+          base_opts = YAML.load_file("#{File.dirname(__FILE__)}/vendor/base.yml")
+          base_args = base_opts[card.to_s]
+          # Validate card is valid
+          args.merge!({ card_name: card })
+          args.merge! base_args if base_args
+          args.merge! vendor_args if vendor_args
+          sym_args = {}
+          args.each_pair do |key, val|
+            sym_args[key.to_sym] = val
+          end
+          Squib::Deck.new **sym_args, &block
         end
-        base_opts = YAML.load_file("#{File.dirname(__FILE__)}/vendor/base.yml")
-        base_args = base_opts[card.to_s]
-        # Validate card is valid
-        args.delete :vendor
-        args.merge! base_args if base_args
-        args.merge! vendor_args if vendor_args
-        # add logic to add blead to height and width
-        sym_args = {}
-        args.each_pair do |key, val|
-          sym_args[key.to_sym] = val
-        end
-        Squib::Deck.new **sym_args, &block
       else
-        super
+        super # run if errors are caught 
       end
     end
 

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -1,14 +1,14 @@
 require 'forwardable'
 require 'pp'
-require 'squib'
-require 'squib/args/unit_conversion'
-require 'squib/card'
-require 'squib/conf'
-require 'squib/constants'
-require 'squib/graphics/hand'
-require 'squib/graphics/showcase'
-require 'squib/layout_parser'
-require 'squib/progress'
+require_relative '../squib.rb'
+require_relative 'args/unit_conversion'
+require_relative 'card'
+require_relative 'conf'
+require_relative 'constants'
+require_relative 'graphics/hand'
+require_relative 'graphics/showcase'
+require_relative 'layout_parser'
+require_relative 'progress'
 
 
 # The project module
@@ -73,6 +73,12 @@ module Squib
       @layout        = LayoutParser.load_layout(layout)
       if block_given?
         instance_eval(&block) # here we go. wheeeee!
+      end
+    end
+
+    def self.missing_method(card, *args, &block)
+      vendor = args.keys.include?(:vendor) ? args[vendor] : none
+      if YAML.load_file("squib/vendor/#{vendor}")
       end
     end
 

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -52,13 +52,15 @@ module Squib
     #
     # @param width [Integer] the width of each card in pixels. Supports unit conversion (e.g. '2.5in').
     # @param height [Integer] the height of each card in pixels. Supports unit conversion (e.g. '3.5in').
-    # @param cards [Integer] the number of cards in the deck
+    # @param cards [Integer] the number of cards in the deck.
     # @param dpi [Integer] the pixels per inch when rendering out to PDF or calculating using inches.
-    # @param config [String] the file used for global settings of this deck
+    # @param bleed [Integer] the size of the bleed in pixels. Supports unit conversion(e.g. '0.125in').
+    # @param config [String] the file used for global settings of this deck.
     # @param layout [String, Array] load a YML file of custom layouts. Multiple files are merged sequentially, redefining collisons. See README and sample for details.
     # @param block [Block] the main body of the script.
     # @api public
-    def initialize(width: 825, height: 1125, cards: 1, dpi: 300, config: 'config.yml', layout: nil, &block)
+    def initialize(width: 825, height: 1125, cards: 1, dpi: 300, bleed: 0, config: 'config.yml', layout: nil, &block)
+      @bleed       = Args::UnitConversion.parse bleed, dpi 
       @dpi           = dpi
       @font          = DEFAULT_FONT
       @cards         = []

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -107,12 +107,13 @@ module Squib
 
     end
 
-    def self.respond_to?(card, priv = false)
-      if card == :poker
-        return true
-      else
-        super
-      end
+    # :nodoc:
+    # @api private
+    def self.respond_to_missing?(card, priv = false)
+        res = Squib::Args::VendorArgs.base_options(card.to_s)
+        return true if res
+      rescue ArgumentError
+        return false
     end
 
     # Directly accesses the array of cards in the deck

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -108,14 +108,14 @@ module Squib
     ##################
     ### PUBLIC API ###
     ##################
-    require 'squib/api/background'
-    require 'squib/api/data'
-    require 'squib/api/image'
-    require 'squib/api/save'
-    require 'squib/api/settings'
-    require 'squib/api/shapes'
-    require 'squib/api/text'
-    require 'squib/api/units'
+    require_relative 'api/background'
+    require_relative 'api/data'
+    require_relative 'api/image'
+    require_relative 'api/save'
+    require_relative 'api/settings'
+    require_relative 'api/shapes'
+    require_relative 'api/text'
+    require_relative 'api/units'
 
   end
 end

--- a/lib/squib/graphics/cairo_context_wrapper.rb
+++ b/lib/squib/graphics/cairo_context_wrapper.rb
@@ -1,5 +1,5 @@
 require 'forwardable'
-require 'squib/graphics/gradient_regex'
+require_relative 'gradient_regex'
 
 module Squib
   module Graphics

--- a/lib/squib/graphics/hand.rb
+++ b/lib/squib/graphics/hand.rb
@@ -1,4 +1,4 @@
-require 'squib/graphics/cairo_context_wrapper'
+require_relative 'cairo_context_wrapper'
 
 module Squib
   class Deck

--- a/lib/squib/graphics/save_doc.rb
+++ b/lib/squib/graphics/save_doc.rb
@@ -65,14 +65,14 @@ module Squib
             x, y = sheet.margin, sheet.margin
             cc = Cairo::Context.new(Cairo::ImageSurface.new(sheet_width, sheet_height))
           end
-          surface = trim(@cards[i].cairo_surface, sheet.trim, @width, @height)
+          card_surface = trim(@cards[i].cairo_surface, sheet.trim)
           cc.set_source(surface, x, y)
           cc.paint
           num_this_sheet += 1
-          x += surface.width + sheet.gap
+          x += card_surface.width + sheet.gap
           if num_this_sheet % sheet.columns == 0 # new row
             x = sheet.margin
-            y += surface.height + sheet.gap
+            y += card_surface.height + sheet.gap
           end
           bar.increment
         end
@@ -88,9 +88,9 @@ module Squib
     # @param height The height of the surface prior to the trim
     # :nodoc:
     # @api private
-    def trim(surface, trim, width, height)
+    def trim(surface, trim)
       if trim > 0
-        tmp = Cairo::ImageSurface.new(width-2*trim, height-2*trim)
+        tmp = Cairo::ImageSurface.new(@width-2*trim, @height-2*trim)
         cc = Cairo::Context.new(tmp)
         cc.set_source(surface,-1*trim, -1*trim)
         cc.paint

--- a/lib/squib/graphics/showcase.rb
+++ b/lib/squib/graphics/showcase.rb
@@ -1,4 +1,4 @@
-require 'squib/graphics/cairo_context_wrapper'
+require_relative 'cairo_context_wrapper'
 
 module Squib
   class Deck

--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -1,5 +1,5 @@
 require 'pango'
-require 'squib/args/typographer'
+require_relative '../args/typographer'
 
 module Squib
   class Card

--- a/lib/squib/vendor/base.yml
+++ b/lib/squib/vendor/base.yml
@@ -2,7 +2,7 @@ poker:
   height: 3.5in
   width: 2.5in
 
-mini: 
+hobbit: 
   height: 2.5in
   width: 1.75in
 

--- a/lib/squib/vendor/base.yml
+++ b/lib/squib/vendor/base.yml
@@ -1,0 +1,25 @@
+poker: 
+  height: 3.5in
+  width: 2.5in
+
+mini: 
+  height: 2.5in
+  width: 1.75in
+
+bridge: 
+  height: 3.5in
+  width: 2.25in
+
+business:
+  height: 4in
+  width: 25in
+
+large: 
+  height: 5in
+  width: 3.5in
+
+square:
+  height: 3.5in
+  width: 3.5in
+
+

--- a/lib/squib/vendor/pnp_productions.yml
+++ b/lib/squib/vendor/pnp_productions.yml
@@ -8,4 +8,4 @@ items:
 
 specs:
   dpi: 300
-  bleed: 0.125in
+  bleed: 0.2cm

--- a/lib/squib/vendor/pnp_productions.yml
+++ b/lib/squib/vendor/pnp_productions.yml
@@ -1,0 +1,11 @@
+items:
+  business
+  poker
+  mini
+  square
+  large
+  bridge
+
+specs:
+  dpi: 300
+  bleed: 0.125in

--- a/lib/squib/version.rb
+++ b/lib/squib/version.rb
@@ -6,5 +6,5 @@ module Squib
   # Most of the time this is in the alpha of the next release.
   # e.g. v0.0.5a is on its way to becoming v0.0.5
   #
-  VERSION = '0.9.0b'
+  VERSION = '0.9.0c'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,11 @@ require 'simplecov'
 require 'coveralls'
 # require 'byebug'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]
+
 SimpleCov.start
 
 require 'squib'


### PR DESCRIPTION
This update lays the groundwork for creating useful defaults for the save_sheet method and provide better n-up support.

It adds a set convenience methods creating decks of preset standard card sizes.  For example, Squib::Deck.poker will create a new deck of poker-size cards.  Additional arguments sent to the method will be passed through to Squib::Deck.new. A vendor argument can also be passed to these methods, which will set additional attributes of the deck to match the requirements of the vendor profile, such as bleed (more below) and dpi.

This method is implemented using the method_missing technique and looks for card sizes and vendor profiles in YAML files in the new lib/squib/vendor directory.  Eventually, I would also like to have these methods look at files in the project directory as well so users can define custom card sizes.

This update also adds some new attributes of deck, most notably bleed.  When specified, the bleed is added to the width and height attributes.  Trim values in the save methods are also set to the bleed by default.  Other additional attributes are card_name and vendor which are set when the new convenience methods are used. 

These changes present useful functionality as-is, and will be important for implementing the better n-up support settings I plan to implement next.

None of these changes impact backwards compatibility.  This update also contains some housekeeping changes I came across when becoming accustomed to the codebase, such as updating deprecated methods, using "require_relative" instead of "require" when appropriate, and fixing typos in the documentation.

All the tests pass except some of the sample_regression ones, which I don't think represent any problems, but I don't feel confident enough with the code to be 100% sure of that.  My manual testing did not present any issues.

Let me know if you have any questions regarding these changes.