### PR TITLE
Utility functions for calculating card ranges.

### DIFF
--- a/lib/squib/api/util.rb
+++ b/lib/squib/api/util.rb
@@ -1,0 +1,23 @@
+# Externally visible utility functions
+module Squib
+  class Deck
+
+    def allSatisfying(data)
+      data.each_index.select{ |i| yield(data[i]) }
+    end
+
+    def allBetweenTypes(data, from, to)
+     id = {} ; data.each_with_index{ |name,i| id[name] = i}
+     id[from]..id[to]
+    end
+
+    def allOfType(data, type)
+      allSatisfying(data) { |v| v == type }
+    end
+
+    def allExceptType(data, type)
+      allSatisfying(data) { |v| v != type }
+    end
+
+  end
+end

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -110,6 +110,7 @@ module Squib
     require_relative 'api/shapes'
     require_relative 'api/text'
     require_relative 'api/units'
+    require_relative 'api/util'
 
   end
 end


### PR DESCRIPTION
Added the idioms for ranges from the documentation as functions. I think it's very convenient to have them as easily accessible functions, so we can write

```
text str: "Is Awesome", range: allSatisfying(data['animal']) { |v| v.includes? "tortoise" }
svg file: "shell-tank.svg", range: allOfType(data['animal'], 'Warrior Tortoise')
```
