### PR TITLE
Adds img_dir in the configuration documentation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -45,6 +45,11 @@ prefix
 
   When using an SVG backend, cards are auto-saved with this prefix and ``'%02d'`` numbering format.
 
+img_dir
+  default: ``'.'``
+  
+  For reading image file command (e.g. png and svg), read from this directory instead
+
 warn_ellipsize
   default: true
 


### PR DESCRIPTION
I had to dig through the codebase in order to determine this could be done.