### PR TITLE
Remove redundant `ArgLoader.convert_unit` to `UnitConversion.parse`.

### DIFF
--- a/lib/squib/args/arg_loader.rb
+++ b/lib/squib/args/arg_loader.rb
@@ -111,26 +111,14 @@ module Squib
           p_str = "@#{p}"
           p_val = instance_variable_get(p_str)
           if p_val.respond_to? :each
-            arr = p_val.map { |x| convert_unit(x, dpi) }
+            arr = p_val.map { |x| UnitConversion.parse(x, dpi) }
             instance_variable_set p_str, arr
           else
-            instance_variable_set p_str, convert_unit(p_val, dpi)
+            instance_variable_set p_str, UnitConversion.parse(p_val, dpi)
           end
         end
         self
       end
-
-      def convert_unit(arg, dpi)
-        case arg.to_s.rstrip
-        when /in$/ # ends with "in"
-          arg.rstrip[0..-2].to_f * dpi
-        when /cm$/ # ends with "cm"
-          arg.rstrip[0..-2].to_f * dpi * INCHES_IN_CM
-        else
-          arg
-        end
-      end
-      module_function :convert_unit
 
     end
 

--- a/lib/squib/args/draw.rb
+++ b/lib/squib/args/draw.rb
@@ -59,7 +59,7 @@ module Squib
 
       def validate_dash(arg, _i)
         arg.to_s.split.collect do |x|
-          convert_unit(x, @dpi).to_f
+          UnitConversion.parse(x, @dpi).to_f
         end
       end
 


### PR DESCRIPTION
Made quick fixes to remove the code redundancy as reference in #161.

Do review :).