### PR TITLE
Use zero-width non-breaking space to make room for images

### DIFF
--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -86,7 +86,7 @@ module Squib
         spacing = rule[:box].width[@index] * Pango::SCALE
         kindex   = clean_str.index(key)
         kindex   = clean_str[0..kindex].bytesize # byte index (bug #57)
-        str = str.sub(key, "\u0091<span letter_spacing=\"#{spacing.to_i}\">\u0091</span>\u0091")
+        str = str.sub(key, "\u2060<span letter_spacing=\"#{spacing.to_i}\">\u2060</span>\u2060")
         layout.markup = str
         clean_str     = layout.text
         searches << { index: kindex, rule: rule }


### PR DESCRIPTION
I ran into some rendering issues on Ubuntu with Unicode code point 0091. Code point 2060 seems to work, since it renders as zero-width.
