### PR TITLE
fix integer division in infinite row calculation

### DIFF
--- a/lib/squib/args/sheet.rb
+++ b/lib/squib/args/sheet.rb
@@ -81,7 +81,7 @@ module Squib
         raise 'columns must be an integer' unless columns.respond_to? :to_i
         return 1 if @deck_size < columns
         return arg if arg.respond_to? :to_i
-        (@deck_size.to_i / columns.to_i).ceil
+        (@deck_size.to_f / columns.to_f).ceil
       end
 
       def full_filename


### PR DESCRIPTION
dividing integers results in `.ceil` being useless and the single sheet being too short if there's a partial row at the end.