### PR TITLE
replace Dir.mkdir with FileUtils.mkdir_p for recursive creation

### DIFF
--- a/lib/squib/args/dir_validator.rb
+++ b/lib/squib/args/dir_validator.rb
@@ -6,7 +6,7 @@ module Squib
       def ensure_dir_created(dir)
         unless Dir.exists?(dir)
           Squib.logger.warn "Dir '#{dir}' does not exist, creating it."
-          Dir.mkdir dir
+          FileUtils.mkdir_p dir
         end
         return dir
       end

--- a/lib/squib/card.rb
+++ b/lib/squib/card.rb
@@ -34,7 +34,7 @@ module Squib
       when :memory
         Cairo::ImageSurface.new(@width, @height)
       when :svg
-        Dir.mkdir @deck.dir unless Dir.exists?(@deck.dir)
+        FileUtils.mkdir_p @deck.dir unless Dir.exists?(@deck.dir)
         Cairo::SVGSurface.new(svgfile, @width, @height)
       else
         Squib.logger.fatal "Back end not recognized: '#{backend}'"


### PR DESCRIPTION
This allows a script to specify `dir: 'foo/bar/baz'` and create all three directories if `foo/` doesn't exist.