### PR TITLE
draw_layouts method to draw multiple layouts at once with their type specified in layout instead of script

### DIFF
--- a/docs/dsl/draw_layouts.rst
+++ b/docs/dsl/draw_layouts.rst
@@ -1,0 +1,19 @@
+draw_layouts
+============
+
+Draw one or more layouts
+
+Options
+-------
+
+pattern
+  default: ``nil``
+
+  regular expression describing the names of the layouts to draw
+
+Also supports every other option that might be used in a drawing primitive.
+
+
+Examples
+--------
+

--- a/lib/squib/api/draw_layouts.rb
+++ b/lib/squib/api/draw_layouts.rb
@@ -1,0 +1,19 @@
+module Squib
+  class Deck
+
+    # DSL method. See http://squib.readthedocs.io
+    def draw_layouts(opts = {})
+      pattern = opts[:pattern]
+      layout.each do |key, value|
+        if /#{pattern}/ =~ key
+          if value['type'] && self.respond_to?(value['type'])
+            new_opts = opts.clone
+            new_opts[:layout] = key.to_sym
+            self.public_send(value['type'],new_opts)
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/lib/squib/deck.rb
+++ b/lib/squib/deck.rb
@@ -111,6 +111,7 @@ module Squib
     require_relative 'api/shapes'
     require_relative 'api/text'
     require_relative 'api/units'
+    require_relative 'api/draw_layouts'
 
   end
 end


### PR DESCRIPTION
This patch provides a new DSL method for drawing one or more layouts at once. `draw_layouts` takes a param named "pattern" which is a regex to choose which layouts to draw. Also any layouts to be drawn this way need a new "type" field in the yaml to indicate which method should be used to draw them.

This will allow a single generic call to draw cutlines whether they are a rectangle or a circle or made of multiple primitives.

example test script and layout file in this gist: https://gist.github.com/sparr/650cdcb20d71a443ecc4604dbf467bb9

the layout file duplicates the existing shapes sample script

the script puts all shapes on one card, just layouts with names ending in "-1" and "-2" on the other two cards, with the -2 layouts having their colors overridden.


seeking feedback on this feature in general, this implementation, the naming of the new method and options, necessary tests, etc.