### PR TITLE
Read deck parameters from the layout file [WIP]

### DIFF
--- a/lib/squib/layout_parser.rb
+++ b/lib/squib/layout_parser.rb
@@ -5,8 +5,14 @@ module Squib
   # @api private
   class LayoutParser
 
-    def initialize(dpi = 300)
-      @dpi = dpi
+    def initialize(dpi = nil)
+      if !dpi
+        @dpi = 300
+        @dpi_force = false
+      else
+        @dpi = dpi
+        @dpi_force = true  
+      end
     end
 
     # Load the layout file(s), if exists
@@ -20,6 +26,9 @@ module Squib
         if File.exists? thefile
           # note: YAML.load_file returns false on empty file
           yml = layout.merge(YAML.load_file(thefile) || {})
+          if !@dpi_force and yml.key? 'deck' and yml['deck'].key? 'dpi'
+            @dpi = yml['deck']['dpi'].to_f
+          end
           yml.each do |key, value|
             layout[key] = recurse_extends(yml, key, {})
           end


### PR DESCRIPTION
This PR is not ready. It is a seedling of an idea, in need of feedback on the approach and implementation.

This PR allows a layout file to contain something like this:

```
deck:
  dpi: 300
  width: 1125
  height: 1725
```

Supplying the above layout file to Deck.new() will provide new default values for the deck. This is useful for loading card width/height from a default template, as in #214.