### PR TITLE
Create a yaml DSL method as an alternative for csv.

### DIFF
--- a/lib/squib/api/data.rb
+++ b/lib/squib/api/data.rb
@@ -121,5 +121,9 @@ module Squib
       Squib.csv(opts)
     end
 
+    # DSL method. See http://squib.readthedocs.io
+    def yaml(opts = {})
+      Squib.yaml(opts)
+    end
   end
 end

--- a/lib/squib/api/data.rb
+++ b/lib/squib/api/data.rb
@@ -1,5 +1,6 @@
 require 'roo'
 require 'csv'
+require 'yaml'
 require_relative '../args/input_file'
 require_relative '../args/import'
 require_relative '../args/csv_opts'
@@ -66,6 +67,22 @@ module Squib
     return explode_quantities(hash, import.explode)
   end
   module_function :csv
+  
+  # DSL method. See http://squib.readthedocs.io
+  def yaml(opts = {})
+    input = Args::InputFile.new(file: 'deck.yml').load!(opts)
+    import = Args::Import.new.load!(opts)
+    s = YAML.load_file(input.file[0])
+    data = Squib::DataFrame.new
+    # Get a universal list of keys to ensure everything is covered.
+    keys = s.map {|c| c.keys}.flatten.uniq
+    # Initialize the data frame; why is [] not the default value?
+    keys.each {|k| data[k] = [] }
+    # Load all cards into the frame, nil value if key isn't set.
+    s.each {|card| keys.each {|k| data[k] << card[k] } }
+    explode_quantities(data, import.explode)
+  end
+  module_function :yaml
 
   # Check if the given CSV table has duplicate columns, and throw a warning
   # @api private

--- a/samples/data/_yaml.rb
+++ b/samples/data/_yaml.rb
@@ -1,0 +1,12 @@
+require 'squib'
+
+Squib::Deck.new(cards: 2) do
+  background color: :white
+
+  # Outputs a hash of arrays with the header names as keys
+  data = yaml file: 'sample.yaml'
+  text str: data['Type'], x: 250, y: 55, font: 'Arial 54'
+  text str: data['Level'], x: 65, y: 65, font: 'Arial 72'
+
+  save format: :png, prefix: 'sample_yaml_'
+end

--- a/samples/data/sample.yaml
+++ b/samples/data/sample.yaml
@@ -1,0 +1,5 @@
+- Type: Thief
+  Level: 1
+
+- Type: Mastermind
+  Level: 2


### PR DESCRIPTION
I find yaml a bit more readable than csv for text-formatted data.

Note that this DSL method doesn't work with multi-doc yaml (that is, `---`-separated documents), and needs an array-formatted file instead:

```yaml
- title: foo
  rank: 2
- title: bar
  rank: 3
```