### PR TITLE
Fix make_sprue unit_conversion FROM mm to other.

### DIFF
--- a/lib/squib/commands/make_sprue.rb
+++ b/lib/squib/commands/make_sprue.rb
@@ -156,6 +156,8 @@ module Squib
           val_mm = val * 25.4
         elsif from_unit == :cm
           val_mm = val * 10.0
+        else
+          val_mm = val
         end
 
         if to_unit == :in


### PR DESCRIPTION
Before, val_mm resulted in nil which broke execution in evaluation of
division operation ("/").

Fixes #259.