### PR TITLE
Update cut zone DSL documentation

### DIFF
--- a/docs/dsl/cut_zone.rst
+++ b/docs/dsl/cut_zone.rst
@@ -10,9 +10,9 @@ Options
 .. include:: /args/expansion.rst
 
 margin
-  default: '0.25in'
+  default: '0.125in'
 
-  The distance from the edge of the card to the safe zone. Supports :doc:`/units`.
+  The distance from the edge of the card to the cut zone. Supports :doc:`/units`.
 
 width
   default: ``width - margin`` (the width of the deck minus the margin)


### PR DESCRIPTION
* Fix margin to standard 1/8* which was intended according to the ruby file used in the examples and specified in the DSL method defaults

https://github.com/andymeneely/squib/blob/f83419defcab1dea35005ace981ced597807eb94/lib/squib/api/shapes.rb#L108

* Fix wording in margin