### PR TITLE
Fix sheet size for 1-card-per-sheet PDFs and adjust coordinates when using trim

### DIFF
--- a/docs/dsl/save_pdf.rst
+++ b/docs/dsl/save_pdf.rst
@@ -19,7 +19,7 @@ dir
 sprue
   default: ``nil``
 
-  the sprue file to use. If ``nil``, then no sprue is used and the cards are laid out automatically using the parameters below. If non-nil, Squib checks for a built-in sprue file of that name. Otherwise, it attempts to open a file relative to the current directory. For more information on Squib Sprues, see :doc:`/sprues`.
+  the sprue file to use. If ``nil``, then no sprue is used and the cards are laid out automatically using the parameters below. If non-nil, Squib checks for a built-in sprue file of that name. Otherwise, it attempts to open a file relative to the current directory. For more information on Squib Sprues, see :doc:`/sprues`. If you use the trim function (see trim option below) the cards are placed considering coordinates reduced by the trim value. A special case is a sprue file which defines one card per sheet: If you use the trim option then the sheet size will be trimmed as well to remove the otherwise added white border in the PDF.
 
 width
   default: ``3300``

--- a/lib/squib/graphics/save_sprue.rb
+++ b/lib/squib/graphics/save_sprue.rb
@@ -29,10 +29,12 @@ module Squib
             card = @deck.cards[i]
             slot = slots[i % per_sheet]
 
-            draw_card cc, card,
-                      slot['x'], slot['y'],
-                      slot['rotate'],
-                      @sheet_args.trim, @sheet_args.trim_radius
+           	draw_card cc, card,
+	            slot['x'] - @sheet_args.trim,
+	            slot['y'] - @sheet_args.trim,
+	            slot['rotate'],
+	            @sheet_args.trim,
+	            @sheet_args.trim_radius
 
             bar.increment
           end
@@ -158,11 +160,21 @@ module Squib
       def init_cc
         ratio = 72.0 / @deck.dpi
 
-        surface = Cairo::PDFSurface.new(
-          full_filename,
-          @tmpl.sheet_width * ratio,
-          @tmpl.sheet_height * ratio
-        )
+        slots = @tmpl.cards
+        per_sheet = slots.size
+	      if per_sheet == 1
+		      surface = Cairo::PDFSurface.new(
+		        full_filename,
+		        (@tmpl.sheet_width - 2 * @sheet_args.trim) * ratio,
+		        (@tmpl.sheet_height - 2 *@sheet_args.trim) * ratio
+		      )
+	      else
+		      surface = Cairo::PDFSurface.new(
+		        full_filename,
+		        @tmpl.sheet_width * ratio,
+		        @tmpl.sheet_height * ratio
+		      )
+	      end
 
         cc = Cairo::Context.new(surface)
         cc.scale(72.0 / @deck.dpi, 72.0 / @deck.dpi) # make it like pixels

--- a/lib/squib/graphics/save_sprue.rb
+++ b/lib/squib/graphics/save_sprue.rb
@@ -29,12 +29,12 @@ module Squib
             card = @deck.cards[i]
             slot = slots[i % per_sheet]
 
-           	draw_card cc, card,
-	            slot['x'] - @sheet_args.trim,
-	            slot['y'] - @sheet_args.trim,
-	            slot['rotate'],
-	            @sheet_args.trim,
-	            @sheet_args.trim_radius
+            draw_card cc, card,
+                slot['x'] - @sheet_args.trim,
+                slot['y'] - @sheet_args.trim,
+                slot['rotate'],
+                @sheet_args.trim,
+                @sheet_args.trim_radius
 
             bar.increment
           end
@@ -162,19 +162,20 @@ module Squib
 
         slots = @tmpl.cards
         per_sheet = slots.size
-	      if per_sheet == 1
-		      surface = Cairo::PDFSurface.new(
-		        full_filename,
-		        (@tmpl.sheet_width - 2 * @sheet_args.trim) * ratio,
-		        (@tmpl.sheet_height - 2 *@sheet_args.trim) * ratio
-		      )
-	      else
-		      surface = Cairo::PDFSurface.new(
-		        full_filename,
-		        @tmpl.sheet_width * ratio,
-		        @tmpl.sheet_height * ratio
-		      )
-	      end
+
+        surface = if per_sheet == 1
+            Cairo::PDFSurface.new(
+                full_filename,
+                (@tmpl.sheet_width - 2 * @sheet_args.trim) * ratio,
+                (@tmpl.sheet_height - 2 *@sheet_args.trim) * ratio
+            )
+        else
+            Cairo::PDFSurface.new(
+                full_filename,
+                @tmpl.sheet_width * ratio,
+                @tmpl.sheet_height * ratio
+            )
+        end
 
         cc = Cairo::Context.new(surface)
         cc.scale(72.0 / @deck.dpi, 72.0 / @deck.dpi) # make it like pixels


### PR DESCRIPTION
The PR takes the trim value into account when building a PDF from a sprue.

I propose it to `dev` branch and I'm unsure too if this is  only a small issue for one specific use case of mine or if it could help others too...but these changes help building PDFs used for printing for one-card-per-sheet PDFs when using trim. I'm not sure too, whether a trim value for a card size should affect the sheet size...

I got a question from a printing shop if I could provide a 1-card-per-sheet PDF for white cards **without** the bleed (to reduce paper waste).  So the trim function is a great way to trim the card without changing the layout (thanks for your awesome documentation! [Always Have Bleed](https://squib.readthedocs.io/en/latest/bleed.html) and section **Safe and Cut** in [Initial Card Layout](https://squib.readthedocs.io/en/latest/guides/getting-started/part_1_zero_to_game.html) and the DSL method `cut_zone` too).

**When using the built-in sprue for 1 card per sheet** (https://github.com/andymeneely/squib/blob/dev/lib/squib/builtin/sprues/drivethrucards_1up.yml) **the trim value of 1/8 inches** removes the bleed from a card for the PNG image file but **leaves a white border in the PDF (unused space) after trimming.** 

The PR adjusts the coordinates for all cards when there is a trim value and reduce the PDF size according to the trim value for PDFs with 1 card per sheet, so only the the effective card size is used for the sheet size.