### PR TITLE
Add sample for color switch in colors docs

### DIFF
--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -119,7 +119,7 @@ It's possible to use that for e.g. background color, text color or to choose the
 
   text str: all_cards['Type'], layout: 'title', color: text_color
 
-  svg file: all_cards['Type'].map { |t|
+  svg layout: 'illustration', file: all_cards['Type'].map do |t|
       if color == 'black' && t == "Type1" then
           "icons/#{t.downcase}-white.svg"
       else

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -100,7 +100,7 @@ It's possible to use that for e.g. background color, text color or to choose the
 
   color = 'black'
 
-  background_color = all_cards['Type'].map { |t|
+  background_color = all_cards['Type'].map do |t|
       if color == 'black' && t == "Type1" then
           "black"
       else

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -106,7 +106,7 @@ It's possible to use that for e.g. background color, text color or to choose the
       else
           "white"
       end
-  }
+  end
   background color: background_color
 
   text_color = all_cards['Type'].map { |t|

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -96,34 +96,17 @@ Say you have different card types with different colors or themes but you would 
 
 You could use something like the following snippet to have one place to define the color/theme and use that in all map functions. The example inverts the color from white to black for one card type. Use a switch-statement inside the map function to differentiate multiple types.
 
-It's possible to use that for e.g. background color, text color or to choose the correct SVG for that color scheme (e.g. use the white or the black version of an image). The sample shows how to define the color at one place, e.g. choose between white and black, to quickly change the color scheme for the cards::
+It's possible to use that for e.g. background color, text color or to choose the correct SVG for that color scheme (e.g. use the white or the black version of an image). The sample shows how to define the color at one place, e.g. choose between white and black, to quickly change the color scheme for the cards:
 
-  color = 'black'
+Here's the data or see the tab-separated file in the sample directory:
 
-  background_color = all_cards['Type'].map do |t|
-      if color == 'black' && t == "Type1" then
-          "black"
-      else
-          "white"
-      end
-  end
-  background color: background_color
+=====  ======================
+Type   Text
+=====  ======================
+Snake  This is a snake.
+Lion   This is a lion.
+=====  ======================
 
-  text_color = all_cards['Type'].map do |t|
-      if color == 'black' && t == "Type1" then
-          "white"
-      else
-          "black"
-      end
-  end
-
-  text str: all_cards['Type'], layout: 'title', color: text_color
-
-  svg layout: 'illustration', file: all_cards['Type'].map do |t|
-      if color == 'black' && t == "Type1" then
-          "icons/#{t.downcase}-white.svg"
-      else
-          "icons/#{t.downcase}.svg"
-      end
-  end
-
+.. literalinclude:: ../samples/colors/_switch_color.rb
+  :language: ruby
+  :linenos:

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -125,5 +125,5 @@ It's possible to use that for e.g. background color, text color or to choose the
       else
           "icons/#{t.downcase}.svg"
       end
-  }, layout: 'illustration'
+  end
 

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -88,3 +88,42 @@ Sample: gradients
 .. raw:: html
 
   <img src="colors/gradient_00_expected.png" width=600 class="figure">
+
+Sample: Switch color based on variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Say you have different card types with different colors or themes but you would like to change the theme quickly without changing all parameters for each method inside ``Squib::Deck.new()``.
+
+You could use something like the following snippet to have one place to define the color/theme and use that in all map functions. The example inverts the color from white to black for one card type. Use a switch-statement inside the map function to differentiate multiple types.
+
+It's possible to use that for e.g. background color, text color or to choose the correct SVG for that color scheme (e.g. use the white or the black version of an image). The sample shows how to define the color at one place, e.g. choose between white and black, to quickly change the color scheme for the cards::
+
+  color = 'black'
+
+  background_color = all_cards['Type'].map { |t|
+      if color == 'black' && t == "Type1" then
+          "black"
+      else
+          "white"
+      end
+  }
+  background color: background_color
+
+  text_color = all_cards['Type'].map { |t|
+      if color == 'black' && t == "Type1" then
+          "white"
+      else
+          "black"
+      end
+  }
+
+  text str: all_cards['Type'], layout: 'title', color: text_color
+
+  svg file: all_cards['Type'].map { |t|
+      if color == 'black' && t == "Type1" then
+          "icons/#{t.downcase}-white.svg"
+      else
+          "icons/#{t.downcase}.svg"
+      end
+  }, layout: 'illustration'
+

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -109,7 +109,7 @@ It's possible to use that for e.g. background color, text color or to choose the
   end
   background color: background_color
 
-  text_color = all_cards['Type'].map { |t|
+  text_color = all_cards['Type'].map do |t|
       if color == 'black' && t == "Type1" then
           "white"
       else

--- a/docs/colors.rst
+++ b/docs/colors.rst
@@ -115,7 +115,7 @@ It's possible to use that for e.g. background color, text color or to choose the
       else
           "black"
       end
-  }
+  end
 
   text str: all_cards['Type'], layout: 'title', color: text_color
 

--- a/samples/colors/_switch_color.rb
+++ b/samples/colors/_switch_color.rb
@@ -1,0 +1,33 @@
+require 'squib'
+
+# Choose between black and white color theme for type snake
+#   * Allow using white snake cards with black text or
+#     black snake cards with white text
+color = 'white'
+
+cards = Squib.csv file: '_switch_color_data.csv', col_sep: "\t"
+
+Squib::Deck.new cards: cards['Type'].size do
+
+    background_color = cards['Type'].map do |t|
+        if color == 'black' && t == "Snake" then
+            "black"
+        else
+            "white"
+        end
+    end
+    background color: background_color
+
+    text_color = cards['Type'].map do |t|
+        if color == 'black' && t == "Snake" then
+            "white"
+        else
+            "black"
+        end
+    end
+
+    text str: cards['Text'], color: text_color
+
+    save_png prefix: '_switch_color_sample_'
+
+end

--- a/samples/colors/_switch_color_data.csv
+++ b/samples/colors/_switch_color_data.csv
@@ -1,0 +1,3 @@
+Type	Text
+Snake	This is a snake.
+Lion	This is a lion.


### PR DESCRIPTION
One of the things I used for a current project was a switch to change the color schemes quickly. I added the snippet in [Specifying Colors & Gradients](https://squib.readthedocs.io/en/latest/colors.html) and in the wiki: https://github.com/andymeneely/squib/wiki/Switch-card-background-or-invert-theme.