### PR TITLE
Fixes a missed rename of RSVG to Rsvg

### DIFF
--- a/lib/squib/graphics/text.rb
+++ b/lib/squib/graphics/text.rb
@@ -67,7 +67,7 @@ module Squib
           end
           return 0 if (file.nil? or file.eql? '') and svg_data.nil?
           svg_data = File.read(file) if svg_data.to_s.empty?
-          RSVG::Handle.new_from_data(svg_data).width
+          Rsvg::Handle.new_from_data(svg_data).width
         end
       else
         rule[:box].width[@index] * Pango::SCALE / (range.size - 1)


### PR DESCRIPTION
### Motivation

Whilst trying to embed SVGs into text I was getting the following error:

```
❯ rake deck
rake aborted!
NameError: uninitialized constant Squib::Card::RSVG

          RSVG::Handle.new_from_data(svg_data).width
          ^^^^
Did you mean?  Rsvg
```

I discovered there had previously been a rename and it looks like this file got missed. I proved this out by first using `bundle open` to change the code and confirming the above command works.

