### PR TITLE
Add support for custom anchors for PNGs and SVGs

### DIFF
--- a/docs/args/anchor.rst
+++ b/docs/args/anchor.rst
@@ -1,0 +1,6 @@
+.. :orphan:
+
+anchor
+  default: ``:top_left``
+
+  the anchor of the image. Available values are ``:top_left``, ``:top_right``, ``:bottom_left``, ``:bottom_right``, and ``:middle`` or ``:center``. The first 4 options anchor the image relative to the corresponding corner, and ``:middle`` and ``:center`` set the anchor to the middle of the image

--- a/docs/dsl/png.rst
+++ b/docs/dsl/png.rst
@@ -12,6 +12,8 @@ file
 
   file(s) to read in. As in :doc:`/arrays`, if this a single file, then it's use for every card in range. If the parameter is an Array of files, then each file is looked up for each card. If any of them are nil or '', nothing is done for that card.
 
+.. include:: /args/anchor.rst
+
 .. include:: /args/xy.rst
 
 width

--- a/docs/dsl/svg.rst
+++ b/docs/dsl/svg.rst
@@ -19,6 +19,8 @@ file
 
   By default, if ``file`` is not found, a warning is logged. This behavior can be configured in :doc:`/config`
 
+.. include:: /args/anchor.rst
+
 .. include:: /args/xy.rst
 
 data

--- a/lib/squib/args/scale_box.rb
+++ b/lib/squib/args/scale_box.rb
@@ -13,7 +13,8 @@ module Squib::Args
     def self.parameters
       {
         x: 0, y: 0,
-        width: :native, height: :native
+        width: :native, height: :native,
+        anchor: :top_left
       }
     end
 
@@ -50,6 +51,11 @@ module Squib::Args
         return arg
       end
       raise 'height must be a number, :scale, :native, or :deck'
+    end
+
+    def validate_anchor(arg, i)
+      raise 'anchor must be one of :top_left, :top_right, :bottom_left, :bottom_right, or :center/:middle' unless [:top_left, :top_right, :bottom_left, :bottom_right, :center, :middle].include? arg
+      arg
     end
 
   end

--- a/lib/squib/dsl/png.rb
+++ b/lib/squib/dsl/png.rb
@@ -25,7 +25,7 @@ module Squib
       def self.accepted_params
         %i(
           file
-          x y width height
+          x y width height anchor
           alpha blend mask angle
           crop_x crop_y crop_width crop_height
           crop_corner_radius crop_corner_x_radius crop_corner_y_radius

--- a/lib/squib/dsl/svg.rb
+++ b/lib/squib/dsl/svg.rb
@@ -26,7 +26,7 @@ module Squib
       def self.accepted_params
         %i(
           file
-          x y width height
+          x y width height anchor
           blend mask
           crop_x crop_y crop_width crop_height
           crop_corner_radius crop_corner_x_radius crop_corner_y_radius

--- a/samples/images/_images.rb
+++ b/samples/images/_images.rb
@@ -1,7 +1,7 @@
 require 'squib'
 require 'squib/sample_helpers'
 
-Squib::Deck.new(width: 1000, height: 3000) do
+Squib::Deck.new(width: 1000, height: 3200) do
   draw_graph_paper width, height
 
   sample "This a PNG.\nNo scaling is done by default." do |x, y|
@@ -99,6 +99,16 @@ Squib::Deck.new(width: 1000, height: 3000) do
     png file: 'with-alpha.png', mask: mask, x: x + 150, y: y, width: 150, height: :scale
   end
 
+  sample 'PNGs and SVGs are top-left-anchored by default but this can be changed.' do |x,y|
+    rect x: x, y: y, width: 100, height: 100,    # draw the crop line
+         dash: '3 3', stroke_color: 'red', stroke_width: 3
+    png  x: x + 50, y: y + 50, width: 100, height: 100, file: 'angler-fish.png',
+         anchor: :center, angle: - Math::PI / 4 - 0.2
+    rect x: x + 150, y: y, width: 100, height: 100,    # draw the crop line
+         dash: '3 3', stroke_color: 'red', stroke_width: 3
+    svg  x: x + 250, y: y + 100, width: 100, height: 100, file: 'robot-golem.svg',
+         anchor: :bottom_right, angle: Math::PI / 5
+  end
 
   save_png prefix: '_images_'
 end

--- a/spec/args/scale_box_spec.rb
+++ b/spec/args/scale_box_spec.rb
@@ -64,6 +64,17 @@ describe Squib::Args::ScaleBox do
       expect { Squib::Args.extract_scale_box args, deck }.to raise_error('height must be a number, :scale, :native, or :deck')
     end
 
+    it 'allows setting anchors' do
+      args = { anchor: :middle }
+      box = Squib::Args.extract_scale_box args, deck
+      expect(box).to have_attributes(anchor: [:middle])
+    end
+
+    it 'disallows setting incorrect anchors' do
+      args = { anchor: :midle }
+      expect { Squib::Args.extract_scale_box args, deck }.to raise_error('anchor must be one of :top_left, :top_right, :bottom_left, :bottom_right, or :center/:middle')
+    end
+
   end
 
 


### PR DESCRIPTION
### Motivation
Hi Andy!

First of all, I'd like to thank you for Squib, it's a great tool that has been a **HUGE** help in my board game project.

As some people have pointed before in https://github.com/andymeneely/squib/discussions/356 and https://github.com/andymeneely/squib/issues/238 for example, having more flexible ways to position images would be super cool, and I too need it for my project.

I have not implemented all the ideas in https://github.com/andymeneely/squib/issues/238, I have only added an `anchor:` argument to the ScaleBox (which is used by the `svg` and `png` dsl methods).

![rotated_anchors](https://github.com/user-attachments/assets/647ab5e8-ebe7-4001-aacf-566acd445143)

I made sure that my changes are retro-compatible. Existing codebases should not be affected at all by these changes if they don't use the new features.

### I have...
  - [x] Written a sample in `_samples`?
  In fact I updated the `samples/images/_images.rb` sample to add an example of images rotating around different anchors
  - [x] Updated documentation in the `docs/` folder?
  - [x] Linked this PR to an issue?
  - [x] Written any automated tests?
  I have written basic unit tests to check the `anchor:` argument validation
  - [x] Refactored your code to be maintainable?
  I tried to make minimal changes and follow the original programming style of the project, but I don't have much experience in Ruby so if you have any suggestions I'm eager to hear them!

### I have not...
- Written extensive tests, as I don't know how to write tests that check that the rendering is correct (I manually tested using sanity though)
- Implemented `anchor:` for `text` or other methods. (I updated the ScaleBox class which is only used by `svg` and `png`)