### PR TITLE
Some packages used to be included in the standard library but will be removed in Ruby 3.4 or 3.5

### DIFF
--- a/squib.gemspec
+++ b/squib.gemspec
@@ -31,6 +31,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(spec|samples|docs|benchmarks)\//)
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'abbrev'
+  spec.add_runtime_dependency 'bigdecimal'
+  spec.add_runtime_dependency 'csv'
+  spec.add_runtime_dependency 'logger'
+  spec.add_runtime_dependency 'ostruct'
   spec.add_runtime_dependency 'cairo',                 '~> 1.17', '>= 1.17.8' # https://rubygems.org/gems/cairo/
   spec.add_runtime_dependency 'classy_hash',           '1.0.0'              # https://rubygems.org/gems/classy_hash
   spec.add_runtime_dependency 'gio2',                  '~> 4.2'   # https://rubygems.org/gems/gio2


### PR DESCRIPTION
A few packages used by Squib are included in the standard library but will be removed in versions 3.4 or 3.5 of Ruby

Example output with a basic test deck:

[...]/ruby/3.3.0/gems/squib-0.20.0/lib/squib.rb:7: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add logger to your Gemfile or gemspec to silence this warning.

[...]/ruby/3.3.0/gems/squib-0.20.0/lib/squib.rb:7: warning: abbrev was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0. You can add abbrev to your Gemfile or gemspec to silence this warning.

[...]/ruby/3.3.0/gems/squib-0.20.0/lib/squib.rb:7: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0. You can add bigdecimal to your Gemfile or gemspec to silence this warning.

[...]/ruby/3.3.0/gems/squib-0.20.0/lib/squib.rb:8: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0. You can add ostruct to your Gemfile or gemspec to silence this warning.

[...]/ruby/3.3.0/gems/squib-0.20.0/lib/squib.rb:8: warning: csv was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0. You can add csv to your Gemfile or gemspec to silence this warning.
