### PR TITLE
Add dependencies removed from default gems in Ruby 3.4.0

### DIFF
--- a/squib.gemspec
+++ b/squib.gemspec
@@ -43,6 +43,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'roo',                   '~> 2.9'             # https://rubygems.org/gems/roo
   spec.add_runtime_dependency 'rsvg2',                 '~> 4.1', '>= 4.1.2'   # https://rubygems.org/gems/rsvg2
   spec.add_runtime_dependency 'ruby-progressbar',      '~> 1.11'            # https://rubygems.org/gems/ruby-progressbar
+  spec.add_runtime_dependency 'bigdecimal',            '~> 3.2', '>= 0'     # https://rubygems.org/gems/bigdecimal/
+  spec.add_runtime_dependency 'csv',                   '~> 3.3', '>= 0'     # https://rubygems.org/gems/csv/
+  spec.add_runtime_dependency 'abbrev',                '~> 0.1', '>= 0'     # https://rubygems.org/gems/abbrev/ This is an unspecified dependency of highline
 
   spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
### Motivation

Ruby 3.4.0 removed a bunch of default gems. The ones used by squib need to be specified.

```
/usr/lib/ruby/3.4.0/did_you_mean/core_ext/name_error.rb:11: warning: bigdecimal is not part of the default gems starting from Ruby 3.4.0. Install bigdecimal from RubyGems.
<internal:/usr/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- bigdecimal (LoadError)
        from <internal:/usr/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /home/sparr/.local/share/gem/ruby/3.4.0/gems/squib-0.19.0/lib/squib/commands/make_sprue.rb:4:in '<top (required)>'
```
```
/usr/lib/ruby/3.4.0/did_you_mean/core_ext/name_error.rb:11: warning: csv is not part of the default gems starting from Ruby 3.4.0. Install csv from RubyGems.
<internal:/usr/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- csv (LoadError)
        from <internal:/usr/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from /home/sparr/.local/share/gem/ruby/3.4.0/gems/squib-0.19.0/lib/squib/args/csv_opts.rb:1:in '<top (required)>'
```

I also included `abbrev` which is a new dependency of `highline`. I opened an issue for them to backport their dependency fix to version 2.1 but that's a long shot. https://github.com/JEG2/highline/issues/280